### PR TITLE
Allow issuer configuration with well-known

### DIFF
--- a/src/oidc-client.ts
+++ b/src/oidc-client.ts
@@ -121,7 +121,8 @@ export class OidcClient {
     }
 
     try {
-      const wellKnownResponse = await fetch(`${Url.trimTrailingSlash(issuerUrl)}/.well-known/openid-configuration`);
+      const url = issuerUrl.match(/\.well-known\/openid-configuration/) ? issuerUrl : `${Url.trimTrailingSlash(issuerUrl)}/.well-known/openid-configuration`;
+      const wellKnownResponse = await fetch(url);
       const responseBody = await wellKnownResponse.json();
 
       return await OidcClient.initializeClient(clientOptions, responseBody);


### PR DESCRIPTION
Fix to allow issuer URL to contain the /.well-known/openid-configuration endpoint. This accomplishes 2 things:
1. The engineer that pastes .well-known/openid-configuration by mistake will get a successful initialization.
2. For certain platforms that have query parameters after the .well-known, the package will still function.